### PR TITLE
DHS-1601 ldap server down retries

### DIFF
--- a/ldap_helper.py
+++ b/ldap_helper.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import time
 import ldap
 
 # Setup logging
@@ -42,18 +41,8 @@ def for_ldap_entries_do( c, base_dn, search_filter, retrieve_attributes, callbac
 ##########################################################
 
 def get_ldap_connection(ldap_host, ldap_user, ldap_pass):
-    max_tries = 5
-    sleep_interval = 120
-    for n in range(max_tries + 1):
-        try:
-            # Setup LDAP connection
-            c = ldap.initialize(ldap_host)
-            c.protocol_version = ldap.VERSION3
-            c.simple_bind_s(ldap_user, ldap_pass)
-            return c
-        except ldap.LDAPError as e:
-            logger.error(str(e))
-            logger.info("retry {0} / {1}".format(n, max_tries))
-            time.sleep(sleep_interval)
-        if n >= max_tries:
-            raise Exception("couldn't connect to LDAP")
+    # Setup LDAP connection
+    c = ldap.initialize(ldap_host)
+    c.protocol_version = ldap.VERSION3
+    c.simple_bind_s(ldap_user, ldap_pass)
+    return c

--- a/sram-sync.py
+++ b/sram-sync.py
@@ -835,10 +835,6 @@ def main(settings):
             logger.warning(str(e))
             logger.warning("LDAP SERVER_DOWN exception has been caught. Will restart in 15 seconds.")
             time.sleep(15)
-        except ldap.LDAPError as e:
-            run_condition = False
-            logger.error(str(e))
-            raise Exception("LDAP error occurred")
         else:
             # Idea here is that we want to die after several connection errors to the LDAP in a row, so
             # if we didn't catch any exceptions, we reset the counter.

--- a/sram-sync.py
+++ b/sram-sync.py
@@ -72,6 +72,8 @@ def parse_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument("--commit", default=False, action='store_true', help="write any updates/changes to iRODS")
     parser.add_argument("--scheduled", default=False, action='store_true', help="if set runs every few minutes")
+    parser.add_argument("--server-down-tries", default=10, action='store', type=int, choices=range(0, 100),
+                        dest='server_down_tries', help="how many times it should re-attempt to connect to LDAP if connection fails")
 
     return parser.parse_args()
 
@@ -784,7 +786,7 @@ def sync_group_memberships(irods, ldap_groups, dry_run):
 ##########################################################
 
 
-def main(dry_run):
+def run(dry_run):
     start_time = datetime.now()
     logger.info("SRAM-SYNC started at: {}".format(start_time))
 
@@ -808,6 +810,41 @@ def main(dry_run):
 
     return 0
 
+def main(settings):
+    ret_val = -1
+    counter_server_down = 0
+    run_condition = True
+
+    while run_condition:
+        try:
+            ret_val = run(not settings.commit)
+            if not settings.scheduled:
+                run_condition = False
+            else:
+                run_condition = True
+                seconds = int(SLEEP_INTERVAL_MINUTES * 60)
+                logger.info("Sleeping for {} seconds".format(seconds))
+                time.sleep(seconds)
+        except ldap.SERVER_DOWN as e:
+            counter_server_down += 1
+            if counter_server_down > settings.server_down_tries:
+                logger.error("Exhausted all attempts ({}) to connect to LDAP SERVER in a row. Aborting execution.".format(settings.server_down_tries))
+                run_condition = False
+                raise Exception("Too many LDAP.SERVER_DOWN")
+
+            logger.warning(str(e))
+            logger.warning("LDAP SERVER_DOWN exception has been caught. Will restart in 15 seconds.")
+            time.sleep(15)
+        except ldap.LDAPError as e:
+            run_condition = False
+            logger.error(str(e))
+            raise Exception("LDAP error occurred")
+        else:
+            # Idea here is that we want to die after several connection errors to the LDAP in a row, so
+            # if we didn't catch any exceptions, we reset the counter.
+            counter_server_down = 0
+
+    return ret_val
 
 ##########################################################
 
@@ -825,13 +862,7 @@ if __name__ == "__main__":
     logger.debug("DEBUG ON")
     print(settings)
     try:
-        exit_code = main(not settings.commit)
-        if settings.scheduled:
-            while True:
-                seconds = int(SLEEP_INTERVAL_MINUTES * 60)
-                logger.info("Sleeping for {} seconds".format(seconds))
-                time.sleep(seconds)
-                main(not settings.commit)
+        exit_code = main(settings)
         sys.exit(exit_code)
     finally:
         # Perform any clean up of connections on closing here


### PR DESCRIPTION
Goal is to die on unexpected LDAP errors, so we pick ldap.SERVER_DOWN as the exception we expect to handle by re-trying, not the more general LDAPError exception.

We also expect to catch this exception (ldap.SERVER_DOWN) anywhere during the execution of the script, not just at the beginning when it establishes connection with ldap server.
