### PR TITLE
Update to python:3.10 (working)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.10
 
 WORKDIR /opt/app
 
@@ -19,7 +19,8 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libldap2-dev \
     libsasl2-dev \
-    libssl-dev
+    libssl-dev \
+    libldap-common
 
 # Python requirements
 ADD requirements.txt /opt


### PR DESCRIPTION
In the past, python images (dockerhub) seemed to have shipped with
package `libldap-common`. This package provides /etc/ldap/ldap.conf,
where a file with all trusted (CA) certificates was specified
(TLS_CACERT)

Newer versions of this image (even new images of older versions of
python, i.e. python:3.6), don't seem to ship with this package. This
produces an error when trying to connect to an LDAP instance via TLS
(ldaps).

[DHDO-316]