### PR TITLE
Add PoC dh_is_ready.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ RUN apt-get update \
 ADD requirements.txt /opt
 RUN pip install -r /opt/requirements.txt
 
+# /dh_is_ready.sh will print READY if sram-sync has run at least once
+ADD dh_is_ready.sh /dh_is_ready.sh
+
 # Entry point
 ADD bootstrap.sh /opt
 RUN chmod +x /opt/bootstrap.sh

--- a/dh_is_ready.sh
+++ b/dh_is_ready.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+
+set -euo pipefail
+
+UPDATE_SYNCS_FILE_PATH="/var/run/sram-syncs"
+
+# Will print given state and exit
+# Args:
+#   $1: status, one of {"READY", "NOT READY"}
+#
+return_status() {
+    echo "$1"
+
+    # return value (0 means success: it is ready)
+    if [[ "$1" == "NOT READY" ]]; then
+        exit 1
+    else
+        exit 0
+    fi
+}
+
+
+if [[ ! -f "${UPDATE_SYNCS_FILE_PATH}" ]]; then
+    return_status "NOT READY"
+fi
+
+# Just an attempt to make sure we are reading an integer
+syncs_value=$(printf "%d" "$(< ${UPDATE_SYNCS_FILE_PATH})") || { return_status "NOT READY"; }
+
+# lower than 1 would mean it hasn't run
+if [[ "${syncs_value}" -lt 1 ]]; then
+    return_status "NOT READY"
+fi
+
+# if we didn't return NOT READY by now.. I guess we're ready
+return_status "READY"

--- a/sram-sync.py
+++ b/sram-sync.py
@@ -71,6 +71,8 @@ IRODS_ZONE = "nlmumc"
 # irods groups and users with this AVU should not be synchronized (i.e. service-accounts, DH-ingest, ...)
 LDAP_SYNC_AVU = "ldapSync"
 
+# Number of runs is kept up to date here
+UPDATE_SYNCS_FILE_PATH = "/var/run/sram-syncs"
 
 ##########################################################
 
@@ -944,10 +946,19 @@ def main(settings):
     ret_val = -1
     counter_server_down = 0
     run_condition = True
+    runs = 0
 
     while run_condition:
         try:
+            # TODO: return value is not meaningful. Perhaps would make sense
+            # returning number of users syncs or groups or something..
             ret_val = run(not settings.commit)
+            # Very rudimentary: keep a file updated with the number of runs
+            # Note: we hackily use this to wait on sram-sync in development
+            runs += 1
+            with open(UPDATE_SYNCS_FILE_PATH, 'w') as syncs_file:
+                syncs_file.write(f"{runs}\n")
+
             if not settings.scheduled:
                 run_condition = False
             else:


### PR DESCRIPTION
In a rudimentary way, we simply have sram-sync write down how many runs has it gone through in a file, that then we can read from dh_is_ready.sh. We will use this later to wait on it in development.

In the future maybe we could have it write to that file something more meaningful..

[DHDO-765]

[DHDO-765]: https://mumc.atlassian.net/browse/DHDO-765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ